### PR TITLE
i remove this to not to use the function generateStaticParams because…

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,0 @@
-// next.config.js
-module.exports = {
-  output: "export", // Enable static export
-};


### PR DESCRIPTION
… i have a dynamic rounting and i don't want to use the output export